### PR TITLE
ft-fetch-all-unread-messages-#164521423

### DIFF
--- a/server/controllers/message.controller.js
+++ b/server/controllers/message.controller.js
@@ -37,6 +37,17 @@ const MessageController = {
       message: 'Fetched Message successfully',
       specificMessage
     });
+  },
+  getUnreadMessage(req, res) {
+    const unreadMessage = MessageModel.fetchUnreadMessage(req.body.status);
+    if (unreadMessage.length === 0) {
+      return res.status(404).json({ message: 'Sorry, there are no unread messages' });
+    }
+    return res.json({
+      status: res.statusCode,
+      message: 'Fetched all unread Messages successfully',
+      unreadMessage
+    });
   }
 };
 

--- a/server/models/message.model.js
+++ b/server/models/message.model.js
@@ -26,6 +26,10 @@ class Message {
   fetchSpecificMessage(id) {
     return this.messages.find(message => message.id === id);
   }
+
+  fetchUnreadMessage() {
+    return this.messages.filter(message => message.status === 'unread');
+  }
 }
 
 export default new Message();

--- a/server/routes/messages.route.js
+++ b/server/routes/messages.route.js
@@ -8,6 +8,7 @@ const router = Router();
 router.post('/', MessageController.sendNewMessage);
 router.get('/', MessageController.getAllMessages);
 router.get('/:id', MessageController.getSpecificMessage);
+router.get('/message/unread', MessageController.getUnreadMessage);
 
 
 export default router;


### PR DESCRIPTION
### What does this PR do?
User should be able to fetch all unread emails.

### Description of Task to be completed?
Setup a route to enable a user to fetch all unread emails using a GET HTTP Method.
Have the following:
A fetchUnreadMessages model in the models folder in the models folder
A getUnreadMessages method in message.controller.js in the controllers folder
A GET HTTP method contained in the messages.routejs in the routes folder

### How should this be manually tested?
This route can be tested on Postman by sending a GET request to localhost:5000/api/v1/message/unread

### Any background context you want to provide?
If there is no message/messages, the user will get a notification that there are no messages

What are the relevant pivotal tracker stories?
EPIC Feature #164521423- fetch all unread emails