### PR TITLE
Feat(user) - delete a group  #164725459

### DIFF
--- a/server/test/groupv2.spec.js
+++ b/server/test/groupv2.spec.js
@@ -66,4 +66,46 @@ describe('Groups', () => {
         });
     });
   });
+  describe('Edit Group Name', () => {
+    it('it should PATCH a group name', (done) => {
+      const group = {
+        statusCode: 201,
+        id: 1,
+        name: 'Group 5',
+        role: 'Food Committee',
+      };
+      chai.request(app)
+        .patch('api/v2/groups/:id/name')
+        .end((err, res) => {
+          expect(groups[0].statusCode).to.equal(200);
+          expect(groups).to.be.an('array');
+          expect(group).to.be.a('object');
+          expect(group).to.have.property('id').to.deep.equal(1);
+          expect(group).to.have.property('name').eql('Group 5');
+          expect(group).to.have.property('role').eql('Food Committee');
+          done();
+        });
+    });
+  });
+  describe('Delete a group', () => {
+    it('it should DELETE a group', (done) => {
+      const group = {
+        statusCode: 201,
+        id: 1,
+        name: 'Group 5',
+        role: 'Food Committee',
+      };
+      chai.request(app)
+        .delete('api/v2/groups/:id/')
+        .end((err, res) => {
+          expect(groups[0].statusCode).to.equal(200);
+          expect(groups).to.be.an('array');
+          expect(group).to.be.a('object');
+          expect(group).to.have.property('id').to.deep.equal(1);
+          expect(group).to.have.property('name').eql('Group 5');
+          expect(group).to.have.property('role').eql('Food Committee');
+          done();
+        });
+    });
+  });
 });

--- a/server/v2/controllers/group.controller.js
+++ b/server/v2/controllers/group.controller.js
@@ -52,6 +52,18 @@ class GroupController {
       editGroupName
     });
   }
+
+  static deleteSpecificGroup(req, res) {
+    const group = GroupModel.oneGroup(Number(req.params.id));
+    if (!group) {
+      res.status(404).json({ message: 'Group is not found' });
+    }
+    GroupModel.deleteOneGroup(Number(req.params.id));
+    res.status(204).send({
+      status: res.statusCode,
+      message: 'Group successfully deleted'
+    });
+  }
 }
 
 export default GroupController;

--- a/server/v2/models/group.model.js
+++ b/server/v2/models/group.model.js
@@ -24,6 +24,11 @@ class Group {
     return this.groups.find(group => group.id === id);
   }
 
+  deleteOneGroup(id) {
+    const group = this.oneGroup(id);
+    const groupIndex = this.groups.indexOf(group);
+    return this.groups.splice(groupIndex, 1);
+  }
 }
 
 export default new Group();

--- a/server/v2/routes/groups.route.js
+++ b/server/v2/routes/groups.route.js
@@ -9,6 +9,7 @@ router.post('/', GroupController.createNewGroup);
 router.get('/', GroupController.fetchAllGroups);
 router.get('/:id', GroupController.getSpecificGroup);
 router.patch('/:id/name', GroupController.patchGroupName);
+router.delete('/:id', GroupController.deleteSpecificGroup);
 
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
- This PR adds a delete group endpoint to the project

#### Description of Task to be completed?
Have the following:
- group model
- group controller 
- group route
- group unit and integration tests

#### How should this be manually tested?
1. User should start the server with `npm run dev-start`
2. Open Postman and makes a DELETE HTTP request to `localhost:5000/api/v2/groups/:id
3. User should receive a success message upon success and deletes a group or get a no group response.

#### Any background context you want to provide?
User should that the server is running before making the DELETE HTTP request

#### What are the relevant pivotal tracker stories?
- #164725459 - Feature - User can delete a group